### PR TITLE
Added Release Sources files

### DIFF
--- a/.github/release_sources.yaml
+++ b/.github/release_sources.yaml
@@ -1,0 +1,5 @@
+# Changes to any file or a file within a directory will trigger a release.
+src:
+  - 'src/**'
+  - 'pyproject.toml'
+  - 'README.md'

--- a/.github/workflows/standard.yaml
+++ b/.github/workflows/standard.yaml
@@ -175,5 +175,7 @@ jobs:
     name: Publish
 
     uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@main
+    with:
+      release_sources_configuration_filename: .github/release_sources.yaml
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/src/PythonProjectBootstrapper/python_project/{{ cookiecutter.__empty_dir }}/.github/release_sources.yaml
+++ b/src/PythonProjectBootstrapper/python_project/{{ cookiecutter.__empty_dir }}/.github/release_sources.yaml
@@ -1,0 +1,5 @@
+# Changes to any file or a file within a directory will trigger a release.
+src:
+  - 'src/**'
+  - 'pyproject.toml'
+  - 'README.md'

--- a/src/PythonProjectBootstrapper/python_project/{{ cookiecutter.__empty_dir }}/.github/workflows/standard.yaml
+++ b/src/PythonProjectBootstrapper/python_project/{{ cookiecutter.__empty_dir }}/.github/workflows/standard.yaml
@@ -189,6 +189,7 @@ jobs:
       bootstrap_args: ""
       docker_description: "{{ cookiecutter.pypi_project_name }} - {% raw %}${{ matrix.python_version }}{% endraw %}"
       push_image_as_package: true
+      container_registry_username: {{ cookiecutter.github_username }}
 {% endif %}
 
   # ----------------------------------------------------------------------
@@ -204,5 +205,7 @@ jobs:
     name: Publish
 
     uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@main
+    with:
+      release_sources_configuration_filename: .github/release_sources.yaml
     secrets:
       PYPI_TOKEN: {% raw %}${{ secrets.PYPI_TOKEN }}{% endraw %}


### PR DESCRIPTION
Changes to files that constitute a release build are now stored in an external file (rather than being hard-coded in the GitHub workflow definition).