### PR TITLE
Script that is run at startup before cookiecutter is invoked

### DIFF
--- a/src/PythonProjectBootstrapper/package/hooks/post_gen_project.py
+++ b/src/PythonProjectBootstrapper/package/hooks/post_gen_project.py
@@ -13,7 +13,7 @@ import textwrap
 from pathlib import Path
 
 from dbrownell_Common import PathEx
-from rich import print
+from rich import print  # pylint: disable=redefined-builtin
 from rich.panel import Panel
 
 

--- a/src/PythonProjectBootstrapper/package/hooks/startup.py
+++ b/src/PythonProjectBootstrapper/package/hooks/startup.py
@@ -1,0 +1,73 @@
+# ----------------------------------------------------------------------
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
+# ----------------------------------------------------------------------
+import sys
+import textwrap
+import uuid
+
+from pathlib import Path
+
+from rich import print  # pylint: disable=redefined-builtin
+from rich.panel import Panel
+
+
+# ----------------------------------------------------------------------
+def Execute(
+    template_dir: Path,  # pylint: disable=unused-argument
+    output_dir: Path,
+    *,
+    yes: bool,
+) -> bool:
+    # Ensure that the panel content is easy to read and modify here, but also leverages Panel's word
+    # wrapping capabilities.
+    panel_content = textwrap.dedent(
+        """\
+        This project creates a Python package hosted on GitHub that uploads a Python wheel to PyPi.
+        It also includes opt-in functionality to create docker images that ensure the exact
+        reproducibility of all commits (which is especially useful for scientific software).
+
+        If you continue, you will be asked a series of questions about your project and given
+        step-by-step instructions on how to set up your project so that it works with 3rd party
+        solutions (GitHub, PyPi, etc.).
+
+        The entire process should take about 10 minutes to complete.
+        """,
+    )
+
+    paragraph_sentinel = str(uuid.uuid4())
+
+    panel_content = (
+        panel_content.replace("\n\n", paragraph_sentinel)
+        .replace("\n", " ")
+        .replace(paragraph_sentinel, "\n\n")
+    )
+
+    sys.stdout.write("\n")
+
+    print(
+        Panel(
+            panel_content.rstrip(),
+            border_style="red",
+            padding=1,
+            title="Python Package",
+        ),
+    )
+
+    if not yes:
+        while True:
+            sys.stdout.write("\nEnter 'yes' to continue or 'no' to exit: ")
+            result = input().strip().lower()
+
+            if result in ["yes", "y"]:
+                break
+
+            if result in ["no", "n"]:
+                return False
+
+    if not (output_dir / ".git").is_dir():
+        raise Exception(f"{output_dir} is not a git repository.")
+
+    return True

--- a/tests/EntryPoint_UnitTest.py
+++ b/tests/EntryPoint_UnitTest.py
@@ -6,6 +6,10 @@
 # ----------------------------------------------------------------------
 """Unit tests for EntryPoint.py"""
 
+from pathlib import Path
+from unittest.mock import patch
+
+from dbrownell_Common import PathEx
 from typer.testing import CliRunner
 
 from PythonProjectBootstrapper import __version__
@@ -17,3 +21,15 @@ def test_Version():
     result = CliRunner().invoke(app, ["package", "<output_dir>", "--version"])
     assert result.exit_code == 0
     assert result.stdout == __version__
+
+
+# ----------------------------------------------------------------------
+def test_Standard():
+    with patch("PythonProjectBootstrapper.EntryPoint.cookiecutter") as mock_cookiecutter:
+        repo_root = PathEx.EnsureDir(Path(__file__).parent.parent)
+
+        result = CliRunner().invoke(app, ["package", str(repo_root), "--yes"])
+
+        assert result.exit_code == 0
+        assert "This project creates a Python package" in result.stdout
+        assert len(mock_cookiecutter.call_args_list) == 1


### PR DESCRIPTION
This script provides context and does some basic error checking before cookiecutter starts bombarding the user with questions. Hopefully, this new information helps the user better understand what is about to happen and opt out if that isn't what they are interested in doing.

https://dev.azure.com/gt-sse-center/Project%20Backlog/_workitems/edit/267

![image](https://github.com/gt-sse-center/PythonProjectBootstrapper/assets/6353056/5aa14215-a76e-4e0c-8967-11c38397c709)
