### PR TITLE
Refined README.md generation and fixed bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PythonProjectBootstrapper
 
 [![CI](https://github.com/gt-sse-center/PythonProjectBootstrapper/actions/workflows/standard.yaml/badge.svg?event=push)](https://github.com/gt-sse-center/PythonProjectBootstrapper/actions/workflows/standard.yaml)
-[![Code Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/gt-sse-center/2f9d770d13e3a148424f374f74d41f4b/raw/PythonProjectBootstrapper_coverage.json)](https://github.com/gt-sse-center/PythonProjectBootstrapper/actions)
+[![Code Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/davidbrownell/2f9d770d13e3a148424f374f74d41f4b/raw/PythonProjectBootstrapper_coverage.json)](https://github.com/gt-sse-center/PythonProjectBootstrapper/actions)
 [![License](https://img.shields.io/github/license/gt-sse-center/PythonProjectBootstrapper?color=dark-green)](https://github.com/gt-sse-center/PythonProjectBootstrapper/blob/master/LICENSE.txt)
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/gt-sse-center/PythonProjectBootstrapper?color=dark-green)](https://github.com/gt-sse-center/PythonProjectBootstrapper/commits/main/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/PythonProjectBootstrapper?color=dark-green)](https://pypi.org/project/pythonprojectbootstrapper/)

--- a/src/PythonProjectBootstrapper/package/cookiecutter.json
+++ b/src/PythonProjectBootstrapper/package/cookiecutter.json
@@ -12,12 +12,13 @@
         "BSL-1.0"
     ],
 
-    "gist_id": "<your gist id>",
-
     "github_url": "https://github.com",
     "github_username": "<your github username>",
     "github_project_name": "<your github repository>",
     "pypi_project_name": "{{ cookiecutter.github_project_name }}",
+
+    "gist_id": "<your gist id>",
+    "gist_username": "{{ cookiecutter.github_username }}",
 
     "create_docker_image": "no",
 
@@ -30,11 +31,12 @@
         "email": "\n\nPlease enter your email address.\n\nThis value will be used in:\n    - Metadata for the generated python package\n    - Metadata for the generated python binary\n\n",
         "project_description": "\n\nPlease enter a short description of your project (less than 100 characters).\n\nThis value will be used in:\n    - Metadata for the generated python package\n    - Metadata for the generated python binary\n\n",
         "license": "\n\nPlease enter the license you would like to use for your project. https://choosealicense.com/ is a\ngood resource that helps you choose the best license for your project.\n\nThis value will be used in:\n    - Population of the License.txt file (or equivalent)\n    - The copyright header for source files\n    - Metadata for the generated python package\n    - Metadata for the generated python binary\n    - Metadata for the generated docker image (if applicable)\n\n",
-        "gist_id": "\n\nPlease enter the GitHub gist id for use with this project.\n\nGitHub defines a gist as \"a simple way to share snippets and pastes with others.\" The generated\npython project will use a gist to store information dynamically generated during the build (for\nexample code coverage information) that can be retrieved at a later time (for example, to display\na code coverage badge in the project's README.md file).\n\nTo create a gist:\n    1. Go to https://gist.github.com/\n    2. Enter the following values in their respective fields:\n\n        Gist description...:                Gist used by GitHub Action workflows to store and retrieve dynamic information (oftentimes used to create and display badges).\n        Filename including extension...:    README.md\n        File contents:                      Gist used by GitHub Action workflows to store and retrieve dynamic information (oftentimes used to create and display badges).\n\n    3. Click the \"Create secret gist\" button\n    4. Copy the gist id (this will be the hex string at the end of the url associated with the gist\n       that was just created). It will look something like:\n\n          https://gist.github.com/<github username>/4c10281ff1abc26cafcb9a5f9a8a443e\n                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n                                                           This is the gist id\n\n",
         "github_url": "\n\nPlease enter the GitHub URL. The default value should be used unless you are running on an GitHub\nEnterprise instance.\n\n    https://github.com/username/projectname\n    ^^^^^^^^^^^^^^^^^^\n    This is the GitHub URL\n\n",
         "github_username": "\n\nPlease enter your GitHub username.\n\n    https://github.com/username/projectname\n                       ^^^^^^^^\n                       This is the GitHub username\n\n",
         "github_project_name": "\n\nPlease enter the name of your GitHub project that corresponds to the output directory.\n\n    https://github.com/username/projectname\n                                ^^^^^^^^^^^\n                                This is the GitHub project name\n\n",
         "pypi_project_name": "\n\nPlease enter the name of your project as it will appear on PyPI (https://pypi.org). This\nname cannot be associated with any other project on PyPI.\n\n",
+        "gist_id": "\n\nPlease enter the GitHub gist id for use with this project.\n\nGitHub defines a gist as \"a simple way to share snippets and pastes with others.\" The generated\npython project will use a gist to store information dynamically generated during the build (for\nexample code coverage information) that can be retrieved at a later time (for example, to display\na code coverage badge in the project's README.md file).\n\nTo create a gist:\n    1. Go to https://gist.github.com/\n    2. Enter the following values in their respective fields:\n\n        Gist description...:                Gist used by GitHub Action workflows to store and retrieve dynamic information (oftentimes used to create and display badges).\n        Filename including extension...:    README.md\n        File contents:                      Gist used by GitHub Action workflows to store and retrieve dynamic information (oftentimes used to create and display badges).\n\n    3. Click the \"Create secret gist\" button\n    4. Copy the gist id (this will be the hex string at the end of the url associated with the gist\n       that was just created). It will look something like:\n\n          https://gist.github.com/<github username>/4c10281ff1abc26cafcb9a5f9a8a443e\n                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n                                                           This is the gist id\n\n",
+        "gist_username": "\n\nPlease enter the username associated with your gist_id. In most cases, this will be the same as your GitHub username.",
         "create_docker_image": "\n\nWould you like the GitHub Action workflows to create docker images of the development environment?\nThese images can be used to produce exact results across different commits made to the repository\nover time (which is especially valuable when writing scientific software).\n\n"
     },
 

--- a/src/PythonProjectBootstrapper/package/cookiecutter_prompts.yaml
+++ b/src/PythonProjectBootstrapper/package/cookiecutter_prompts.yaml
@@ -33,30 +33,6 @@ license: |-
       - Metadata for the generated python binary
       - Metadata for the generated docker image (if applicable)
 
-gist_id: |-
-  Please enter the GitHub gist id for use with this project.
-
-  GitHub defines a gist as "a simple way to share snippets and pastes with others." The generated
-  python project will use a gist to store information dynamically generated during the build (for
-  example code coverage information) that can be retrieved at a later time (for example, to display
-  a code coverage badge in the project's README.md file).
-
-  To create a gist:
-      1. Go to https://gist.github.com/
-      2. Enter the following values in their respective fields:
-
-          Gist description...:                Gist used by GitHub Action workflows to store and retrieve dynamic information (oftentimes used to create and display badges).
-          Filename including extension...:    README.md
-          File contents:                      Gist used by GitHub Action workflows to store and retrieve dynamic information (oftentimes used to create and display badges).
-
-      3. Click the "Create secret gist" button
-      4. Copy the gist id (this will be the hex string at the end of the url associated with the gist
-         that was just created). It will look something like:
-
-            https://gist.github.com/<github username>/4c10281ff1abc26cafcb9a5f9a8a443e
-                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                                                             This is the gist id
-
 github_url: |-
   Please enter the GitHub URL. The default value should be used unless you are running on an GitHub
   Enterprise instance.
@@ -82,6 +58,32 @@ github_project_name: |-
 pypi_project_name: |-
   Please enter the name of your project as it will appear on PyPI (https://pypi.org). This
   name cannot be associated with any other project on PyPI.
+
+gist_id: |-
+  Please enter the GitHub gist id for use with this project.
+
+  GitHub defines a gist as "a simple way to share snippets and pastes with others." The generated
+  python project will use a gist to store information dynamically generated during the build (for
+  example code coverage information) that can be retrieved at a later time (for example, to display
+  a code coverage badge in the project's README.md file).
+
+  To create a gist:
+      1. Go to https://gist.github.com/
+      2. Enter the following values in their respective fields:
+
+          Gist description...:                Gist used by GitHub Action workflows to store and retrieve dynamic information (oftentimes used to create and display badges).
+          Filename including extension...:    README.md
+          File contents:                      Gist used by GitHub Action workflows to store and retrieve dynamic information (oftentimes used to create and display badges).
+
+      3. Click the "Create secret gist" button
+      4. Copy the gist id (this will be the hex string at the end of the url associated with the gist
+         that was just created). It will look something like:
+
+            https://gist.github.com/<github username>/4c10281ff1abc26cafcb9a5f9a8a443e
+                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                             This is the gist id
+gist_username: |-
+  Please enter the username associated with your gist_id. In most cases, this will be the same as your GitHub username.
 
 create_docker_image: |-
   Would you like the GitHub Action workflows to create docker images of the development environment?

--- a/src/PythonProjectBootstrapper/package/{{ cookiecutter.__empty_dir }}/README.md
+++ b/src/PythonProjectBootstrapper/package/{{ cookiecutter.__empty_dir }}/README.md
@@ -1,7 +1,7 @@
 # {{ cookiecutter.github_project_name }}
 
 [![CI]({{ cookiecutter.github_url }}/{{ cookiecutter.github_username }}/{{ cookiecutter.github_project_name }}/actions/workflows/standard.yaml/badge.svg?event=push)]({{ cookiecutter.github_url }}/{{ cookiecutter.github_username }}/{{ cookiecutter.github_project_name }}/actions/workflows/standard.yaml)
-[![Code Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/{{ cookiecutter.github_username }}/{{ cookiecutter.gist_id }}/raw/{{ cookiecutter.github_project_name }}_coverage.json)]({{ cookiecutter.github_url }}/{{ cookiecutter.github_username }}/{{ cookiecutter.github_project_name }}/actions)
+[![Code Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/{{ cookiecutter.gist_username }}/{{ cookiecutter.gist_id }}/raw/{{ cookiecutter.github_project_name }}_coverage.json)]({{ cookiecutter.github_url }}/{{ cookiecutter.github_username }}/{{ cookiecutter.github_project_name }}/actions)
 [![License](https://img.shields.io/github/license/{{ cookiecutter.github_username }}/{{ cookiecutter.github_project_name }}?color=dark-green)]({{ cookiecutter.github_url }}/{{ cookiecutter.github_username }}/{{ cookiecutter.github_project_name }}/blob/master/LICENSE.txt)
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/{{ cookiecutter.github_username }}/{{ cookiecutter.github_project_name }}?color=dark-green)]({{ cookiecutter.github_url }}/{{ cookiecutter.github_username }}/{{ cookiecutter.github_project_name }}/commits/main/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/{{ cookiecutter.pypi_project_name }}?color=dark-green)](https://pypi.org/project/{{ cookiecutter.pypi_project_name | pypi_string }}/)
@@ -19,136 +19,53 @@ TODO: Complete this section
 
 TODO: Complete this section
 
+## Installation via Executable
+
+Download an executable for Linux, MacOS, or Windows to use the functionality provided by this repository without a dependency on [Python](https://www.python.org).
+
+1. Download the archive for the latest release [here]({{ cookiecutter.github_url }}/{{ cookiecutter.github_username }}/{{ cookiecutter.github_project_name }}/releases/latest); the files will begin with `exe.` and contain the name of your operating system.
+2. Decompress the archive
+
 ## Installation via pip
+
+Install the {{ cookiecutter.pypi_project_name }} package via [pip](https://pip.pypa.io/en/stable/) (Package Installer for Python) to use it with your python code.
 
 `pip install {{ cookiecutter.pypi_project_name }}`
 
 ## Local Development
 
+Follow these steps to prepare the repository for local development activities.
+
 1) Clone this repository
 2) Bootstrap the local repository by running...
-    <table>
-        <tr>
-            <th>Operating System</th>
-            <th>Command</th>
-        </tr>
-        <tr>
-            <td>Linux / MacOS</td>
-            <td><code>Bootstrap.sh --package</code></td>
-        </tr>
-        <tr>
-            <td>Windows</td>
-            <td><code>Bootstrap.cmd --package</code></td>
-        </tr>
-    </table>
+    | Operating System | Command |
+    | --- | --- |
+    | Linux / MacOS | <p>Standard:<br/>`Bootstrap.sh`</p><p>Standard + packaging:<br/>`Bootstrap.sh --package`</p> |
+    | Windows | <p>Standard:<br/>`Bootstrap.cmd`</p><p>Standard + packaging:<br/>`Bootstrap.cmd --package`</p> |
 3) Activate the development environment by running...
-    <table>
-        <tr>
-            <th>Operating System</th>
-            <th>Command</th>
-        </tr>
-        <tr>
-            <td>Linux / MacOS</td>
-            <td><code>. ./Activate.sh</code></td>
-        </tr>
-        <tr>
-            <td>Windows</td>
-            <td><code>Activate.cmd</code></td>
-        </tr>
-    </table>
+    | Operating System | Command |
+    | --- | --- |
+    | Linux / MacOS | `. ./Activate.sh` |
+    | Windows | `Activate.cmd` |
 4) Invoke `Build.py`
-    <table>
-        <tr>
-            <th>Command</th>
-            <th>Description</th>
-            <th>Example</th>
-        </tr>
-        <tr>
-            <td><code>black</code></td>
-            <td>Validates that the source code is formatted by <a href="https://github.com/psf/black" target="_blank">black</a>.</td>
-            <td>
-                <p>
-                    Validation:<br/>
-                    <code>python Build.py black</code>
-                </p>
-                <p>
-                    Perform formatting:<br/>
-                    <code>python Build.py black --format</code>
-                </p>
-            </td>
-        </tr>
-        <tr>
-            <td><code>pylint</code></td>
-            <td>Validates the source code using <a href="https://github.com/pylint-dev/pylint" target="_blank">pylint</a>.</td>
-            <td><code>python Build.py pylint</code></td>
-        </tr>
-        <tr>
-            <td><code>pytest</code></py>
-            <td>Runs automated tests using <a href="https://docs.pytest.org/" target="_blank">pytest</a>.</td>
-            <td>
-                <p>
-                    Without Code Coverage:<br/>
-                    <code>python Build.py pytest</code>
-                </p>
-                <p>
-                    With Code Coverage:<br/>
-                    <code>python Build.py pytest --code-coverage</code>
-                </p>
-            </td>
-        </tr>
-        <tr>
-            <td><code>update_version</code></td>
-            <td>Updates the <a href="https://semver.org/" target="_blank">semantic version</a> of the package based on git commits using <a href="https://github.com/davidbrownell/AutoGitSemVer" target="_blank">AutoGitSemVer</a>.</td>
-            <td><code>python Build.py update_version</code></td>
-        </tr>
-        <tr>
-            <td><code>package</code></td>
-            <td>Creates a Python wheel package for distribution; outputs to the <code>/dist</code> directory.</td>
-            <td><code>python Build.py package</code></td>
-        </tr>
-        <tr>
-            <td><code>publish</code></td>
-            <td>Publishes a Python wheel package to <a href="https://pypi.org/" target="_blank">PyPi</a>.</td>
-            <td>
-                <p>
-                    <a href="https://test.pypi.org/" target="_blank">https://test.pypi.org</a>:<br/>
-                    <code>python Build.py publish &lt;your PyPi API token here&gt;</code>
-                </p>
-                <p>
-                    <a href="https://pypi.org/" target="_blank">https://pypi.org</a>:<br/>
-                    <code>python Build.py publish &lt;your PyPi API token here&gt; --production</code>
-                </p>
-            </td>
-        </tr>
-        <tr>
-            <td><code>build_binary</code></td>
-            <td>Builds an executable for your package that can be run on machines without a python installation; outputs to the <code>/build</code> directory.</td>
-            <td><code>python Build.py build_binary</code></td>
-        </tr>
-{%- if cookiecutter.create_docker_image -%}
-        <tr>
-            <td><code>create_docker_image</code></td>
-            <td>Creates a <a href="https://www.docker.com/" target="_blank">Docker</a> image based on the current development environment. This supports the "Reusable" aspect of <a href="https://www.go-fair.org/fair-principles/" target="_blank">FAIR principles</a> by creating a snapshot of the repository and all of its dependencies as they exist in a single moment in time.</td>
-            <td><code>python Build.py create_docker_image</code></td>
-        </tr>
+    | Command | Description | Example | Notes |
+    | --- | --- | --- | --- |
+    | `black` | Validates that the source code is formatted by [black](https://github.com/psf/black). | <p>Validation:<br/>`python Build.py black`</p><p>Perform formatting:<br/>`python Build.py black --format`</p> | |
+    | `pylint` | Validates the source code using [pylint](https://github.com/pylint-dev/pylint). | `python Build.py pylint` | |
+    | `pytest` | Runs automated tests using [pytest](https://docs.pytest.org/). | <p>Without Code Coverage:<br/>`python Build.py pytest`</p><p>With Code Coverage:<br/>`python Build.py pytest --code-coverage`</p> | |
+    | `update_version` | Updates the [semantic version](https://semver.org/) of the package based on git commits using [AutoGitSemVer](https://github.com/davidbrownell/AutoGitSemVer). | `python Build.py update_version` | |
+    | `package` | Creates a Python wheel package for distribution; outputs to the `/dist` directory. | `python Build.py package` | Requires `--package` when bootstrapping in step #2. |
+    | `publish` | Publishes a Python wheel package to [PyPi](https://pypi.org/). | <p>https://test.pypi.org:<br/>`python Build.py publish`</p><p>https://pypi.org:<br/>`python Build.py publish --production`</p> | Requires `--package` when bootstrapping in step #2. |
+    | `build_binary` | Builds an executable for your package that can be run on machines without a python installation; outputs to the `/build` directory. | `python Build.py build_binary` | Requires `--package` when bootstrapping in step #2. |
+{%- if cookiecutter.create_docker_image %}
+    | `create_docker_image` | Creates a [Docker](https://www.docker.com/) image based on the current development environment. This supports the "Reusable" aspect of [FAIR principles](https://www.go-fair.org/fair-principles/) by creating a snapshot of the repository and all of its dependencies as they exist in a single moment in time. | `python Build.py create_docker_image` | Requires docker. |
 {% endif %}
-    </table>
 
-5) [Optional] Deactivate the development environment by running:
-    <table>
-        <tr>
-            <th>Operating System</th>
-            <th>Command</th>
-        </tr>
-        <tr>
-            <td>Linux / MacOS</td>
-            <td><code>. ./Deactivate.sh</code></td>
-        </tr>
-        <tr>
-            <td>Windows</td>
-            <td><code>Deactivate.cmd</code></td>
-        </tr>
-    </table>
+5) [Optional] Deactivate the development environment by running...
+    | Operating System | Command |
+    | --- | --- |
+    | Linux / MacOS | `. ./Deactivate.sh` |
+    | Windows | `Deactivate.cmd` |
 
 ## License
 

--- a/src/PythonProjectBootstrapper/package/{{ cookiecutter.__empty_dir }}/src/{{ cookiecutter.pypi_project_name }}/__init__.py
+++ b/src/PythonProjectBootstrapper/package/{{ cookiecutter.__empty_dir }}/src/{{ cookiecutter.pypi_project_name }}/__init__.py
@@ -1,6 +1,7 @@
+{%- include "python_header.py" -%}
 # pylint: disable=missing-module-docstring,invalid-name
 
-# Note that this value will be overwritten by calls to `python ../../Build.py UpdateVersion` based
+# Note that this value will be overwritten by calls to `python ../../Build.py update_version` based
 # on changes observed in the git repository. The default value below will be used until the value
 # here is explicitly updated as part of a commit.
 __version__ = "0.1.0"


### PR DESCRIPTION
- Added gist_username template variable (when the gist user is different from the GitHub user (which happens with the GitHub username points to an organization (which doesn't support gists)))
- Using markdown tables rather than HTML tables
- Added "Installation via Executable" section
- Added description to installation sections

See https://github.com/gt-sse-center/PythonProjectBootstrapperTest2 for an example of the output.