### PR TITLE
Update post gen hook to change access permissions on all systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Deactivate*.sh
 build/**
 dist/**
 src/PythonProjectBootstrapper.egg-info/**
+.DS_Store

--- a/src/PythonProjectBootstrapper/package/hooks/post_gen_project.py
+++ b/src/PythonProjectBootstrapper/package/hooks/post_gen_project.py
@@ -161,6 +161,15 @@ _prompts: dict[str, str] = {
 
 
 # ----------------------------------------------------------------------
+def UpdateBootstrapExecutionPermissions():
+    bootstrap_path = Path("./Bootstrap.sh")
+
+    PathEx.EnsureFile(bootstrap_path)
+    status = bootstrap_path.stat()
+    bootstrap_path.chmod(status.st_mode | 0o700)
+
+
+# ----------------------------------------------------------------------
 def UpdateLicenseFile():
     this_dir = Path.cwd()
     licenses_dir = PathEx.EnsureDir(this_dir / "Licenses")
@@ -232,5 +241,6 @@ def FinalPrompt():
 # ----------------------------------------------------------------------
 # ----------------------------------------------------------------------
 UpdateLicenseFile()
+UpdateBootstrapExecutionPermissions()
 DisplayPrompts()
 FinalPrompt()


### PR DESCRIPTION
Previously, post gen hook had Windows specific instruction to change access permissions for `Bootstrap.sh`. These access permissions changes are required on Ubuntu and macOS as well

### Testing
Verified that generated GitHub Actions workflows run to completion on all systems (seen [here](https://github.com/varun646/PythonProjectBootstrapperTest/actions/runs/8457315295))