### PR TITLE
Added decoration when bootstrapped w/package flag

### DIFF
--- a/ActivateEpilog.py
+++ b/ActivateEpilog.py
@@ -1,0 +1,19 @@
+# ----------------------------------------------------------------------
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
+# ----------------------------------------------------------------------
+# pylint: disable=missing-module-docstring
+
+import json
+import os
+import sys
+
+from pathlib import Path
+
+with (Path(os.environ["PYTHON_BOOTSTRAPPER_GENERATED_DIR"]) / "bootstrap_flags.json").open() as f:
+    flags = json.load(f)
+
+if flags:
+    sys.stdout.write("\nBootstrapped with {}.\n".format(", ".join(f"'{flag}'" for flag in flags)))

--- a/BootstrapEpilog.py
+++ b/BootstrapEpilog.py
@@ -6,8 +6,11 @@
 # ----------------------------------------------------------------------
 # pylint: disable=missing-module-docstring
 
+import os
 import subprocess
 import sys
+
+from pathlib import Path
 
 # Parse the arguments
 is_debug = False
@@ -15,6 +18,8 @@ is_force = False
 is_verbose = False
 is_package = False
 no_cache = False
+
+display_flags: list[str] = []
 
 for arg in sys.argv[
     2:
@@ -27,6 +32,7 @@ for arg in sys.argv[
         is_verbose = True
     elif arg == "--package":
         is_package = True
+        display_flags.append("package")
     elif arg == "--no-cache":
         no_cache = True
     else:
@@ -43,3 +49,9 @@ subprocess.run(
     check=True,
     shell=True,
 )
+
+
+with (
+    Path(__file__).parent / os.environ["PYTHON_BOOTSTRAPPER_GENERATED_DIR"] / "bootstrap_flags.json"
+).open("w") as f:
+    f.write("[{}]".format(", ".join(f'"{flag}"' for flag in display_flags)))


### PR DESCRIPTION
Displays text when the repository was bootstrapped with the package flag. This is helpful when asking yourself the question "when I bootstrapped this repository, did I remember to include the package flag?"

![image](https://github.com/gt-sse-center/PythonProjectBootstrapper/assets/6353056/5ac84ab8-f750-4511-bd79-c70471cd31f7)
