### PR TITLE
Update execution permissions for bootstrap.sh

### DIFF
--- a/src/PythonProjectBootstrapper/package/hooks/post_gen_project.py
+++ b/src/PythonProjectBootstrapper/package/hooks/post_gen_project.py
@@ -161,6 +161,14 @@ _prompts: dict[str, str] = {
 
 
 # ----------------------------------------------------------------------
+def UpdateBootstrapExecutionPermissions():
+    bootstrap_path = Path("./Bootstrap.sh")
+
+    PathEx.EnsureFile(bootstrap_path)
+    status = bootstrap_path.stat()
+    bootstrap_path.chmod(status.st_mode | 0o700)
+
+# ----------------------------------------------------------------------
 def UpdateLicenseFile():
     this_dir = Path.cwd()
     licenses_dir = PathEx.EnsureDir(this_dir / "Licenses")
@@ -232,5 +240,6 @@ def FinalPrompt():
 # ----------------------------------------------------------------------
 # ----------------------------------------------------------------------
 UpdateLicenseFile()
+UpdateBootstrapExecutionPermissions()
 DisplayPrompts()
 FinalPrompt()

--- a/src/PythonProjectBootstrapper/package/hooks/post_gen_project.py
+++ b/src/PythonProjectBootstrapper/package/hooks/post_gen_project.py
@@ -168,6 +168,7 @@ def UpdateBootstrapExecutionPermissions():
     status = bootstrap_path.stat()
     bootstrap_path.chmod(status.st_mode | 0o700)
 
+
 # ----------------------------------------------------------------------
 def UpdateLicenseFile():
     this_dir = Path.cwd()


### PR DESCRIPTION
Allow `bootstrap.sh` to be executed on all systems. Windows still requires user to update permissions through `git update-index`