### PR TITLE
Display modifications

### DIFF
--- a/src/PythonProjectBootstrapper/EntryPoint.py
+++ b/src/PythonProjectBootstrapper/EntryPoint.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Annotated, Optional
 
 import typer
+import yaml
 
 from typer.core import TyperGroup  # type: ignore [import-untyped]
 
@@ -236,8 +237,18 @@ def _ExecuteOutputDir(
 
     modifications = CopyToOutputDir(src_dir=tmp_dir, dest_dir=output_dir)
 
+    prompt_text_path = PathEx.EnsureFile(output_dir / "prompt_text.yml")
+
     if not skip_prompts:
-        DisplayPrompt(output_dir=output_dir, modifications=modifications)
+        with open(prompt_text_path, "r") as prompt_file:
+            prompts = yaml.load(prompt_file, Loader=yaml.Loader)
+
+        prompt_text_path.unlink()
+
+        DisplayPrompt(output_dir=output_dir, modifications=modifications, prompts=prompts)
+
+    else:
+        prompt_text_path.unlink()
 
 
 if __name__ == "__main__":

--- a/src/PythonProjectBootstrapper/EntryPoint.py
+++ b/src/PythonProjectBootstrapper/EntryPoint.py
@@ -234,10 +234,10 @@ def _ExecuteOutputDir(
             accept_hooks=True,
         )
 
-    CopyToOutputDir(src_dir=tmp_dir, dest_dir=output_dir)
+    modifications = CopyToOutputDir(src_dir=tmp_dir, dest_dir=output_dir)
 
     if not skip_prompts:
-        DisplayPrompt(output_dir=output_dir)
+        DisplayPrompt(output_dir=output_dir, modifications=modifications)
 
 
 if __name__ == "__main__":

--- a/src/PythonProjectBootstrapper/EntryPoint.py
+++ b/src/PythonProjectBootstrapper/EntryPoint.py
@@ -27,7 +27,12 @@ from PythonProjectBootstrapper import __version__
 from PythonProjectBootstrapper.ProjectGenerationUtils import (
     CopyToOutputDir,
     DisplayPrompt,
+    DisplayModifications,
+    prompt_filename,
 )
+
+# from PythonProjectBootstrapper.package.hooks.post_gen_project import prompt_filename
+# prompt_filename = "prompt_text.yml"
 
 # The following imports are used in cookiecutter hooks. Import them here to
 # ensure that they are frozen when creating binaries,
@@ -237,18 +242,22 @@ def _ExecuteOutputDir(
 
     modifications = CopyToOutputDir(src_dir=tmp_dir, dest_dir=output_dir)
 
-    prompt_text_path = PathEx.EnsureFile(output_dir / "prompt_text.yml")
+    prompt_text_path = PathEx.EnsureFile(output_dir / prompt_filename)
+
+    # The approach below with reading in the prompt file regardless of whether or not we will display the prompts is not ideal but has to be
+    # done since we need to remove the prompt_text file before running DisplayPrompt(). This is because prompt_text.yml is currently stored in the output directory
+    # and the instructions being printed out during the execution of DisplayPrompt() would result in that file being check into the git repo.
+    # Alternate solutions would be to only read in the file in the 'if' block below, but, this would result in us needing the call 'unlink()' in both the 'if' block and a separate 'else' block.
+    # This issue also prevents us from using a cleaner solution such as ExitStack()
+    with open(prompt_text_path, "r") as prompt_file:
+        prompts = yaml.load(prompt_file, Loader=yaml.Loader)
+
+    prompt_text_path.unlink()
+
+    DisplayModifications(modifications=modifications)
 
     if not skip_prompts:
-        with open(prompt_text_path, "r") as prompt_file:
-            prompts = yaml.load(prompt_file, Loader=yaml.Loader)
-
-        prompt_text_path.unlink()
-
-        DisplayPrompt(output_dir=output_dir, modifications=modifications, prompts=prompts)
-
-    else:
-        prompt_text_path.unlink()
+        DisplayPrompt(output_dir=output_dir, prompts=prompts)
 
 
 if __name__ == "__main__":

--- a/src/PythonProjectBootstrapper/ProjectGenerationUtils.py
+++ b/src/PythonProjectBootstrapper/ProjectGenerationUtils.py
@@ -197,15 +197,10 @@ def CopyToOutputDir(
 
 
 # ----------------------------------------------------------------------
-def DisplayPrompt(output_dir: Path, modifications: list[set[str]]) -> None:
+def DisplayPrompt(output_dir: Path, modifications: list[set[str]], prompts: str) -> None:
     PathEx.EnsureDir(output_dir)
 
-    prompt_text_path = PathEx.EnsureFile(output_dir / "prompt_text.yml")
-
-    with open(prompt_text_path, "r") as prompt_file:
-        _prompts = yaml.load(prompt_file, Loader=yaml.Loader)
-
-    prompt_text_path.unlink()
+    _prompts = prompts
 
     # Display prompts
     border_colors = itertools.cycle(

--- a/src/PythonProjectBootstrapper/ProjectGenerationUtils.py
+++ b/src/PythonProjectBootstrapper/ProjectGenerationUtils.py
@@ -92,7 +92,7 @@ def ConditionallyRemoveUnchangedTemplateFiles(
 def CopyToOutputDir(
     src_dir: Path,
     dest_dir: Path,
-):
+) -> list[set[str]]:
     # Copies all generated files into the output directory and handles the creation/updating of the manifest file
 
     PathEx.EnsureDir(src_dir)
@@ -197,7 +197,7 @@ def CopyToOutputDir(
 
 
 # ----------------------------------------------------------------------
-def DisplayPrompt(output_dir: Path, modifications) -> None:
+def DisplayPrompt(output_dir: Path, modifications: list[set[str]]) -> None:
     PathEx.EnsureDir(output_dir)
 
     prompt_text_path = PathEx.EnsureFile(output_dir / "prompt_text.yml")

--- a/src/PythonProjectBootstrapper/ProjectGenerationUtils.py
+++ b/src/PythonProjectBootstrapper/ProjectGenerationUtils.py
@@ -200,8 +200,6 @@ def CopyToOutputDir(
 def DisplayPrompt(output_dir: Path, modifications: list[set[str]], prompts: str) -> None:
     PathEx.EnsureDir(output_dir)
 
-    _prompts = prompts
-
     # Display prompts
     border_colors = itertools.cycle(
         ["yellow", "blue", "magenta", "cyan", "green"],
@@ -231,13 +229,13 @@ def DisplayPrompt(output_dir: Path, modifications: list[set[str]], prompts: str)
 
     # ----------------------------------------------------------------------
     # Print out saved prompts
-    for prompt_index, ((_, title), prompt) in enumerate(sorted(_prompts.items())):
+    for prompt_index, ((_, title), prompt) in enumerate(sorted(prompts.items())):
         print(
             Panel(
                 prompt.rstrip(),
                 border_style=next(border_colors),
                 padding=1,
-                title=f"[{prompt_index + 1}/{len(_prompts)}] {title}",
+                title=f"[{prompt_index + 1}/{len(prompts)}] {title}",
                 title_align="left",
             ),
         )

--- a/src/PythonProjectBootstrapper/package/hooks/post_gen_project.py
+++ b/src/PythonProjectBootstrapper/package/hooks/post_gen_project.py
@@ -13,12 +13,14 @@ from pathlib import Path
 
 from dbrownell_Common import PathEx
 
+prompt_filename = "prompt_text.yml"
+
 
 # ----------------------------------------------------------------------
 def SavePrompts():
     # Instructions for post generation
     #
-    # By not displaying the prompts right away, we allow the integration of a DoneManager (is this how you spell it?)
+    # By not displaying the prompts right away, we allow the integration of a DoneManager
     # so we can let the user know when the cookiecutter generation is done and before them seeing all the prompts
     #
     #
@@ -164,7 +166,7 @@ def SavePrompts():
         ),
     }
 
-    with open("prompt_text.yml", "w") as prompt_file:
+    with open(prompt_filename, "w") as prompt_file:
         yaml.dump(_prompts, prompt_file)
 
 

--- a/tests/ProjectGenerationUtils_UnitTest.py
+++ b/tests/ProjectGenerationUtils_UnitTest.py
@@ -92,12 +92,13 @@ def test_ConditionalRemoveTemplateFiles_no_changed_files(fs):
     existing_manifest = CreateManifest(generated_dir=output_dir_path)
     new_manifest = CreateManifest(generated_dir=new_output_path)
 
-    ConditionallyRemoveUnchangedTemplateFiles(
+    deleted_files = ConditionallyRemoveUnchangedTemplateFiles(
         new_manifest_dict=new_manifest,
         existing_manifest_dict=existing_manifest,
         output_dir=Path("output_dir"),
     )
 
+    assert deleted_files == [str(output_dir_path / "testFile3")]
     assert _dirs_equal(output_dir_path, new_output_path)
 
 
@@ -122,12 +123,13 @@ def testConditionalRemoveTemplateFiles_files_changed(fs):
 
     new_manifest = CreateManifest(generated_dir=new_output_path)
 
-    ConditionallyRemoveUnchangedTemplateFiles(
+    deleted_files = ConditionallyRemoveUnchangedTemplateFiles(
         new_manifest_dict=new_manifest,
         existing_manifest_dict=existing_manifest,
         output_dir=output_dir_path,
     )
 
+    assert deleted_files == []
     assert _dirs_equal(output_dir_path, expected_output_dir)
 
 
@@ -186,7 +188,11 @@ def test_CopyToOutputDir_no_prompt(fs):
 
     fs.create_dir(dest)
 
-    CopyToOutputDir(src_dir=src, dest_dir=dest)
+    directory_changes = CopyToOutputDir(src_dir=src, dest_dir=dest)
 
+    assert directory_changes.added_files == ["dest/test/file1", "dest/test/file2"]
+    assert directory_changes.deleted_files == []
+    assert directory_changes.overwritten_files == []
+    assert directory_changes.modified_template_files == []
     assert _dirs_equal(expected, dest)
     assert (dest / ".manifest.yml").is_file()


### PR DESCRIPTION
### Changes
- `CopyToOutputDir` returns list of sets containing info about what files were deleted, added, overwritten, and modified due to changes in the template
- `ConditionallyRemoveTemplateFiles` returns a set of files removed
- `DisplayPrompt` displays changes to files
- `prompt_text.yml` is removed from any existing manifests and no longer added to manifest files. It was previously added to the manifest files since the manifest is generated based on the temporary directory, before `prompt_text.yml` was removed from there 
- Reading of contents and removal of `prompt_text.yml` is moved outside of `DisplayPrompt()` function so the file is removed when using the `--skip-prompts` flag

**Future changes**
Will make another PR to address the comments that need to be added to `manifest.yml` and to add documentation explaining some of the logic