### PR TITLE
Removed python files incorrectly included in the package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,5 +167,8 @@ python_files = [
 [tool.setuptools.dynamic]
 version = { attr = "PythonProjectBootstrapper.__version__" }
 
+[tool.setuptools.packages.find]
+where = ["src"]
+
 [tool.setuptools.package-data]
 "PythonProjectBootstrapper.package" = ["**"]

--- a/src/PythonProjectBootstrapper/package/{{ cookiecutter.__empty_dir }}/pyproject.toml
+++ b/src/PythonProjectBootstrapper/package/{{ cookiecutter.__empty_dir }}/pyproject.toml
@@ -164,3 +164,6 @@ python_files = [
 # ----------------------------------------------------------------------
 [tool.setuptools.dynamic]
 version = { attr = "{{ cookiecutter.pypi_project_name | escape_double_quotes }}.__version__" }
+
+[tool.setuptools.packages.find]
+where = ["src"]


### PR DESCRIPTION
Prior to this change, files at the root of the src directory were incorrectly included in generated packages.