### PR TITLE
Pinned CI dependencies

### DIFF
--- a/.github/workflows/standard.yaml
+++ b/.github/workflows/standard.yaml
@@ -23,7 +23,7 @@ jobs:
   # ----------------------------------------------------------------------
   action_contexts:
     name: "Display GitHub Action Contexts"
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.15.5
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.15.6
 
   # ----------------------------------------------------------------------
   validate:
@@ -45,7 +45,7 @@ jobs:
 
     name: Validate
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.15.5
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.15.6
     with:
       operating_system: ${{ matrix.os }}
       python_version: ${{ matrix.python_version }}
@@ -55,9 +55,8 @@ jobs:
     needs: validate
 
     name: Postprocess Coverage Info
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.15.5
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.15.6
     with:
       gist_id: 2f9d770d13e3a148424f374f74d41f4b
       gist_filename: PythonProjectBootstrapper_coverage.json
@@ -86,7 +85,7 @@ jobs:
 
     name: Create Package
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.15.5
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.15.6
     with:
       operating_system: ${{ matrix.os }}
       python_version: ${{ matrix.python_version }}
@@ -113,7 +112,7 @@ jobs:
 
     name: Validate Package
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.15.5
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.15.6
     with:
       operating_system: ${{ matrix.os }}
       python_version: ${{ matrix.python_version }}
@@ -137,7 +136,7 @@ jobs:
 
     name: Create Binary
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.15.5
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.15.6
     with:
       operating_system: ${{ matrix.os }}
       python_version: ${{ matrix.python_version }}
@@ -160,7 +159,7 @@ jobs:
 
     name: Validate Binary
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.15.5
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.15.6
     with:
       operating_system: ${{ matrix.os }}
       python_version: ${{ matrix.python_version }}
@@ -174,7 +173,7 @@ jobs:
 
     name: Publish
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.15.5
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.15.6
     with:
       release_sources_configuration_filename: .github/release_sources.yaml
     secrets:

--- a/src/PythonProjectBootstrapper/package/{{ cookiecutter.__empty_dir }}/.github/workflows/standard.yaml
+++ b/src/PythonProjectBootstrapper/package/{{ cookiecutter.__empty_dir }}/.github/workflows/standard.yaml
@@ -18,7 +18,7 @@ jobs:
   # ----------------------------------------------------------------------
   action_contexts:
     name: "Display GitHub Action Contexts"
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.15.5
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.15.6
 
   # ----------------------------------------------------------------------
   validate:
@@ -40,7 +40,7 @@ jobs:
 
     name: Validate
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.15.5
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.15.6
     with:
       operating_system: {% raw %}${{ matrix.os }}{% endraw %}
       python_version: {% raw %}${{ matrix.python_version }}{% endraw %}
@@ -50,9 +50,8 @@ jobs:
     needs: validate
 
     name: Postprocess Coverage Info
-    if: {% raw %}${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}{% endraw %}
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.15.5
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.15.6
     with:
       gist_id: {{ cookiecutter.gist_id }}
       gist_filename: {{ cookiecutter.github_project_name }}_coverage.json
@@ -81,7 +80,7 @@ jobs:
 
     name: Create Package
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.15.5
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.15.6
     with:
       operating_system: {% raw %}${{ matrix.os }}{% endraw %}
       python_version: {% raw %}${{ matrix.python_version }}{% endraw %}
@@ -108,7 +107,7 @@ jobs:
 
     name: Validate Package
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.15.5
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.15.6
     with:
       operating_system: {% raw %}${{ matrix.os }}{% endraw %}
       python_version: {% raw %}${{ matrix.python_version }}{% endraw %}
@@ -132,7 +131,7 @@ jobs:
 
     name: Create Binary
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.15.5
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.15.6
     with:
       operating_system: {% raw %}${{ matrix.os }}{% endraw %}
       python_version: {% raw %}${{ matrix.python_version }}{% endraw %}
@@ -155,7 +154,7 @@ jobs:
 
     name: Validate Binary
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.15.5
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.15.6
     with:
       operating_system: {% raw %}${{ matrix.os }}{% endraw %}
       python_version: {% raw %}${{ matrix.python_version }}{% endraw %}
@@ -179,7 +178,7 @@ jobs:
 
     name: Create Docker Image
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.15.5
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.15.6
     with:
       operating_system: ubuntu-latest
       python_version: {% raw %}${{ matrix.python_version }}{% endraw %}
@@ -201,7 +200,7 @@ jobs:
 
     name: Publish
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.15.5
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.15.6
     with:
       release_sources_configuration_filename: .github/release_sources.yaml
     secrets:


### PR DESCRIPTION
With these changes, code coverage information will be displayed for all builds and only used for the coverage badge on pushes to main.