### PR TITLE
Changed `.manifest.yml` to `.python_project_bootstrapper_manifest.yml`

### DIFF
--- a/src/PythonProjectBootstrapper/ProjectGenerationUtils.py
+++ b/src/PythonProjectBootstrapper/ProjectGenerationUtils.py
@@ -175,7 +175,7 @@ def CopyToOutputDir(
     1. If a file in the src_dir does not exist in the dest_dir, copy it over
     2. If a file in the src_dir exists in the dest_dir, copy it over only if the file in the dest_dir has never been modified by the user OR after prompted, they approve overwriting their changes
 
-    Additionally, write the final manifest to "<dest_dir>/.manifest.yml". This manifest should reflect the state of the output directory after the project generation has completed
+    Additionally, write the final manifest to "<dest_dir>/.python_project_bootstrapper_manifest.yml". This manifest should reflect the state of the output directory after the project generation has completed
 
     Args:
         src_dir (Path): path to source dir
@@ -202,7 +202,7 @@ def CopyToOutputDir(
     modified_template_files: list[str] = []
     unchanged_files_deleted: list[str] = []
 
-    potential_manifest: Path = dest_dir / ".manifest.yml"
+    potential_manifest: Path = dest_dir / ".python_project_bootstrapper_manifest.yml"
 
     # if this is not our first time generating, remove unwanted template files
     if potential_manifest.is_file():

--- a/src/PythonProjectBootstrapper/package/hooks/post_gen_project.py
+++ b/src/PythonProjectBootstrapper/package/hooks/post_gen_project.py
@@ -303,7 +303,7 @@ def SavePrompts() -> None:
         """,
     )
 
-    prompts["Commit and Push the Repository"] = textwrap.dedent(
+    prompts["Commit and Push the OpenSSF Best Practices Badge ID Changes"] = textwrap.dedent(
         """\
         1. Run 'git add --all'
         2. Run 'git commit -m "🎉 Updated README.md with OpenSSF Best Practices Badge ID"'

--- a/tests/ProjectGenerationUtils_UnitTest.py
+++ b/tests/ProjectGenerationUtils_UnitTest.py
@@ -29,14 +29,14 @@ def _dirs_equal(dir1: Path, dir2: Path) -> bool:
     generated_files2: list[Path] = []
 
     for root, _, files in os.walk(dir1):
-        if ".manifest.yml" in files:
-            files.remove(".manifest.yml")
+        if ".python_project_bootstrapper_manifest.yml" in files:
+            files.remove(".python_project_bootstrapper_manifest.yml")
 
         generated_files1 += [Path(root) / Path(file) for file in files]
 
     for root, _, files in os.walk(dir2):
-        if ".manifest.yml" in files:
-            files.remove(".manifest.yml")
+        if ".python_project_bootstrapper_manifest.yml" in files:
+            files.remove(".python_project_bootstrapper_manifest.yml")
 
         generated_files2 += [Path(root) / Path(file) for file in files]
 
@@ -166,7 +166,7 @@ def test_CopyToOutputDir_overwritePrompt(fs, overwrite):
         with open(dest / path, "r") as destfile:
             assert content == destfile.read()
 
-    manifest_filepath = dest / ".manifest.yml"
+    manifest_filepath = dest / ".python_project_bootstrapper_manifest.yml"
     assert manifest_filepath.is_file()
 
     # check that manifest file has read-only permissions
@@ -199,7 +199,7 @@ def test_CopyToOutputDir_no_prompt(fs):
     fs.create_dir(dest)
 
     directory_changes = CopyToOutputDir(src_dir=src, dest_dir=dest)
-    manifest_filepath = dest / ".manifest.yml"
+    manifest_filepath = dest / ".python_project_bootstrapper_manifest.yml"
 
     assert directory_changes.added_files == ["dest/test/file1", "dest/test/file2"]
     assert directory_changes.deleted_files == []


### PR DESCRIPTION
This change is necessary because the file `.python_project_bootstrapper_config.yml` will be introduced in a future change.

Also no longer overwriting initial git commit prompt.